### PR TITLE
Correction of an installation error in a future version of zpm

### DIFF
--- a/module.xml
+++ b/module.xml
@@ -3,7 +3,7 @@
   <Document name="native-api-objectscript.ZPM">
     <Module>
       <Name>native-api-objectscript</Name>
-      <Version>1.0.1</Version>
+      <Version>1.0.2</Version>
       <Description>Small demo how to use IRIS Native API between IRIS instances</Description>
       <Keywords>Terminal, Native API</Keywords>
       <Packaging>module</Packaging>

--- a/src/rcc/ONAPI/Address.cls
+++ b/src/rcc/ONAPI/Address.cls
@@ -13,4 +13,27 @@ Property State As %String(MAXLEN = 2, POPSPEC = "USState()");
 
 /// The 5-digit U.S. Zone Improvement Plan (ZIP) code.
 Property Zip As %String(MAXLEN = 5, POPSPEC = "USZip()");
+
+Storage Default
+{
+<Data name="AddressState">
+<Value name="1">
+<Value>Street</Value>
+</Value>
+<Value name="2">
+<Value>City</Value>
+</Value>
+<Value name="3">
+<Value>State</Value>
+</Value>
+<Value name="4">
+<Value>Zip</Value>
+</Value>
+</Data>
+<State>AddressState</State>
+<StreamLocation>^rcc.ONAPI.AddressS</StreamLocation>
+<Type>%Storage.Serial</Type>
 }
+
+}
+

--- a/src/rcc/ONAPI/Company.cls
+++ b/src/rcc/ONAPI/Company.cls
@@ -1,4 +1,4 @@
-/// This sample persistent class represents a company.<br>
+/// This sample persistent class represents a company<br>
 Class rcc.ONAPI.Company Extends (%Persistent, %Populate, %XML.Adaptor, %JSON.Adaptor)
 {
 
@@ -32,4 +32,32 @@ ClassMethod JSON(id As %Integer) As %String(MAXLEN="") [ CodeMode = objectgenera
  do %code.WriteLine(" quit jsn")
 }
 
+Storage Default
+{
+<Data name="CompanyDefaultData">
+<Value name="1">
+<Value>%%CLASSNAME</Value>
+</Value>
+<Value name="2">
+<Value>Name</Value>
+</Value>
+<Value name="3">
+<Value>Mission</Value>
+</Value>
+<Value name="4">
+<Value>TaxID</Value>
+</Value>
+<Value name="5">
+<Value>Revenue</Value>
+</Value>
+</Data>
+<DataLocation>^rcc.ONAPI.CompanyD</DataLocation>
+<DefaultData>CompanyDefaultData</DefaultData>
+<IdLocation>^rcc.ONAPI.CompanyD</IdLocation>
+<IndexLocation>^rcc.ONAPI.CompanyI</IndexLocation>
+<StreamLocation>^rcc.ONAPI.CompanyS</StreamLocation>
+<Type>%Storage.Persistent</Type>
 }
+
+}
+

--- a/src/rcc/ONAPI/Employee.cls
+++ b/src/rcc/ONAPI/Employee.cls
@@ -16,4 +16,30 @@ Property Picture As %Stream.GlobalBinary;
 
 /// The company this employee works for.
 Relationship Company As Company [ Cardinality = one, Inverse = Employees ];
+
+Storage Default
+{
+<Data name="EmployeeDefaultData">
+<Subscript>"Employee"</Subscript>
+<Value name="1">
+<Value>Title</Value>
+</Value>
+<Value name="2">
+<Value>Salary</Value>
+</Value>
+<Value name="3">
+<Value>Notes</Value>
+</Value>
+<Value name="4">
+<Value>Picture</Value>
+</Value>
+<Value name="5">
+<Value>Company</Value>
+</Value>
+</Data>
+<DefaultData>EmployeeDefaultData</DefaultData>
+<Type>%Storage.Persistent</Type>
 }
+
+}
+

--- a/src/rcc/ONAPI/Person.cls
+++ b/src/rcc/ONAPI/Person.cls
@@ -47,4 +47,41 @@ ClassMethod JSON(id As %Integer) As %String(MAXLEN="") [ CodeMode = objectgenera
  do %code.WriteLine(" quit jsn")
 }
 
+Storage Default
+{
+<Data name="PersonDefaultData">
+<Value name="1">
+<Value>%%CLASSNAME</Value>
+</Value>
+<Value name="2">
+<Value>Name</Value>
+</Value>
+<Value name="3">
+<Value>SSN</Value>
+</Value>
+<Value name="4">
+<Value>DOB</Value>
+</Value>
+<Value name="5">
+<Value>Home</Value>
+</Value>
+<Value name="6">
+<Value>Office</Value>
+</Value>
+<Value name="7">
+<Value>Spouse</Value>
+</Value>
+<Value name="8">
+<Value>FavoriteColors</Value>
+</Value>
+</Data>
+<DataLocation>^rcc.ONAPI.PersonD</DataLocation>
+<DefaultData>PersonDefaultData</DefaultData>
+<IdLocation>^rcc.ONAPI.PersonD</IdLocation>
+<IndexLocation>^rcc.ONAPI.PersonI</IndexLocation>
+<StreamLocation>^rcc.ONAPI.PersonS</StreamLocation>
+<Type>%Storage.Persistent</Type>
 }
+
+}
+

--- a/src/rcc/ONAPI/demo.cls
+++ b/src/rcc/ONAPI/demo.cls
@@ -94,3 +94,4 @@ Method Menu(ByRef go As %Boolean = 1)
 }
 
 }
+


### PR DESCRIPTION
This module has a persistent class without any specific storage and this is stated in the error.
The author must define the Storage and publish the new version. The new version of the zpm will have an installation error.
 Update the release in Open Exchange please.
https://openexchange.intersystems.com/markdown?url=assets%2Fdoc%2Freleases.md
Thanks.

%SYS>ver
%SYS> zpm 0.2.15-dev.228.5
USER>install native-api-objectscript                     
[native-api-objectscript]       Reload START (D:\InterSystems\IRISPY\mgr\.modules\COLLECTIONINDEXANDQUERY\native-api-objectscript\1.0.1\)
[native-api-objectscript]       Reload SUCCESS
[native-api-objectscript]       Module object refreshed.
[native-api-objectscript]       Validate START
[native-api-objectscript]       Validate SUCCESS
[native-api-objectscript]       Compile START
[native-api-objectscript]       Compile FAILURE
ERROR! Storage on class rcc.ONAPI.Address modified by storage compiler, developer should have run ^build to make sure all storage is updated correctly and saved to Perforce               